### PR TITLE
Read only fix

### DIFF
--- a/Sparkle/SUHost.m
+++ b/Sparkle/SUHost.m
@@ -109,6 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isRunningOnReadOnlyVolume
 {
+    NSLog(@"🍒 %s(%@)", __PRETTY_FUNCTION__, [self.bundle bundlePath]);
     struct statfs statfs_info;
     statfs([[self.bundle bundlePath] fileSystemRepresentation], &statfs_info);
     return (statfs_info.f_flags & MNT_RDONLY) != 0;

--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -130,7 +130,7 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
             sharedUpdaters = [[NSMutableDictionary alloc] init];
         }
         [sharedUpdaters setObject:self forKey:[NSValue valueWithNonretainedObject:bundle]];
-        host = [[SUHost alloc] initWithBundle:bundle];
+        self.host = [[SUHost alloc] initWithBundle:bundle];
 
         // This runs the permission prompt if needed, but never before the app has finished launching because the runloop won't run before that
         [self performSelector:@selector(startUpdateCycle) withObject:nil afterDelay:0];


### PR DESCRIPTION
potential fix for strange Jenkins-only Sparkle alert at startup

**AND**

console debugging just in case fix doesn't work, we can see WTH path isn't read/write